### PR TITLE
feat(ui): add chat header with theme switcher

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,12 @@
+@import url('https://fonts.googleapis.com/css2?family=Sansation:wght@700&display=swap');
 @import 'tailwindcss';
 @import 'tw-animate-css';
+
+.sansation-bold {
+  font-family: 'Sansation', sans-serif;
+  font-weight: 700;
+  font-style: normal;
+}
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,9 +18,7 @@ export default function Home() {
             <ResizablePanel minSize={10} defaultSize={30}>
               <Chat />
             </ResizablePanel>
-            <div className="bg-foreground mx-2">
-              <ResizableHandle isWithHandle className="h-full" />
-            </div>
+            <ResizableHandle />
             <ResizablePanel minSize={40} defaultSize={70}>
               <Editor />
             </ResizablePanel>

--- a/src/components/chat/chat-header.tsx
+++ b/src/components/chat/chat-header.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { SunIcon, MoonIcon, MonitorIcon } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import * as React from 'react';
+
+import { ApiKeyManagerButton } from '@/components/custom/api-key-manager-button';
+import { useApiKey } from '@/components/providers/api-key-provider';
+import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  TooltipProvider,
+} from '@/components/ui/tooltip';
+import useTooltipGroup from '@/lib/hooks/use-tooltip-group';
+
+interface ChatHeaderProps {
+  onApiKeyEditClick: () => void;
+}
+
+export default function ChatHeader({ onApiKeyEditClick }: ChatHeaderProps) {
+  const { hasApiKey } = useApiKey();
+  const { setTheme, theme } = useTheme();
+  const [mounted, setMounted] = React.useState(false);
+  const tooltipGroup = useTooltipGroup();
+  console.log({ theme });
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <div className="flex items-center justify-between gap-2 p-2">
+        <div className="h-10 w-32" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      onMouseLeave={tooltipGroup.onGroupMouseLeave}
+      className="border-border flex items-center gap-2 border-b p-2"
+    >
+      <div className="flex basis-full items-center justify-between">
+        <div className="px-2">
+          <h3 className="sansation-bold scroll-m-20 text-2xl font-semibold tracking-tight text-slate-600 dark:text-slate-300">
+            <span className="border-b border-dashed border-slate-600 dark:border-slate-300">
+              Textual
+            </span>{' '}
+            Chat
+          </h3>
+        </div>
+        <div className="[&>*]:rounded-none [&>*]:first:rounded-l-md [&>*]:last:rounded-r-md">
+          <TooltipProvider>
+            <Tooltip
+              delayDuration={tooltipGroup.getTooltipProps().delayDuration}
+            >
+              <TooltipTrigger
+                asChild
+                onMouseEnter={tooltipGroup.getTooltipProps().onMouseEnter}
+              >
+                <Button
+                  size="icon"
+                  variant={theme === 'light' ? 'secondary' : 'ghost'}
+                  onClick={() => {
+                    setTheme('light');
+                  }}
+                >
+                  <SunIcon className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <span className="text-sm">Light</span>
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip
+              delayDuration={tooltipGroup.getTooltipProps().delayDuration}
+            >
+              <TooltipTrigger
+                asChild
+                onMouseEnter={tooltipGroup.getTooltipProps().onMouseEnter}
+              >
+                <Button
+                  size="icon"
+                  variant={theme === 'system' ? 'secondary' : 'ghost'}
+                  onClick={() => {
+                    setTheme('system');
+                  }}
+                >
+                  <MonitorIcon className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <span className="text-sm">System</span>
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip
+              delayDuration={tooltipGroup.getTooltipProps().delayDuration}
+            >
+              <TooltipTrigger
+                asChild
+                onMouseEnter={tooltipGroup.getTooltipProps().onMouseEnter}
+              >
+                <Button
+                  size="icon"
+                  variant={theme === 'dark' ? 'secondary' : 'ghost'}
+                  onClick={() => {
+                    setTheme('dark');
+                  }}
+                >
+                  <MoonIcon className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <span className="text-sm">Dark</span>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+      </div>
+
+      {hasApiKey && <ApiKeyManagerButton onEditClick={onApiKeyEditClick} />}
+    </div>
+  );
+}

--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -9,8 +9,8 @@ import * as React from 'react';
 import { useState } from 'react';
 
 import { ChatEmptyState } from '@/components/chat/chat-empty-state';
+import ChatHeader from '@/components/chat/chat-header';
 import { ApiKeyDialog } from '@/components/custom/api-key-dialog';
-import { ApiKeyManagerButton } from '@/components/custom/api-key-manager-button';
 import { useApiKey } from '@/components/providers/api-key-provider';
 import { ChatStatusContext } from '@/components/providers/chat-status-provider';
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
@@ -126,6 +126,11 @@ export default function Chat() {
   if (!hasApiKey) {
     return (
       <>
+        <ChatHeader
+          onApiKeyEditClick={() => {
+            return setShowApiKeyDialog(true);
+          }}
+        />
         <ChatEmptyState
           onSetApiKey={() => {
             return setShowApiKeyDialog(true);
@@ -145,16 +150,24 @@ export default function Chat() {
 
   return (
     <>
-      <div className="flex h-full flex-col justify-between overflow-x-auto p-2 pb-2">
-        <ApiKeyManagerButton
-          className="fixed m-4"
-          onEditClick={() => {
+      <ApiKeyDialog
+        isOpen={showApiKeyDialog}
+        onOpenChange={setShowApiKeyDialog}
+        onApiKeySet={(key) => {
+          setApiKey(key);
+          setShowApiKeyDialog(false);
+        }}
+      />
+
+      <div className="flex h-full flex-col overflow-x-auto">
+        <ChatHeader
+          onApiKeyEditClick={() => {
             return setShowApiKeyDialog(true);
           }}
         />
 
-        <div className="flex-1 overflow-y-auto">
-          <div className="flex flex-col gap-4 pt-2 pl-2">
+        <div className="flex flex-1 flex-col justify-between overflow-y-auto p-4">
+          <div className="flex flex-col gap-4 pt-2">
             {error && (
               <Alert variant="destructive">
                 <AlertTitle>Error</AlertTitle>
@@ -346,28 +359,19 @@ export default function Chat() {
               <LoaderPinwheelIcon className="mx-auto animate-spin" />
             )}
           </div>
+
+          <form className="m-2 mt-4" onSubmit={submitMessage}>
+            <Input
+              value={input}
+              disabled={status === 'submitted'}
+              placeholder="Add a paragraph or edit existing content..."
+              onChange={(e) => {
+                return setInput(e.currentTarget.value);
+              }}
+            />
+          </form>
         </div>
-
-        <form className="m-2 mt-4" onSubmit={submitMessage}>
-          <Input
-            value={input}
-            disabled={status === 'submitted'}
-            placeholder="Add a paragraph or edit existing content..."
-            onChange={(e) => {
-              return setInput(e.currentTarget.value);
-            }}
-          />
-        </form>
       </div>
-
-      <ApiKeyDialog
-        isOpen={showApiKeyDialog}
-        onOpenChange={setShowApiKeyDialog}
-        onApiKeySet={(key) => {
-          setApiKey(key);
-          setShowApiKeyDialog(false);
-        }}
-      />
     </>
   );
 }

--- a/src/components/custom/api-key-manager-button.tsx
+++ b/src/components/custom/api-key-manager-button.tsx
@@ -43,7 +43,7 @@ export function ApiKeyManagerButton({
     <Popover>
       <PopoverTrigger asChild>
         <Button
-          size="icon"
+          size="sm"
           variant="outline"
           title="Manage API Key"
           className={cn(
@@ -51,7 +51,7 @@ export function ApiKeyManagerButton({
             className
           )}
         >
-          <Key className="h-4 w-4" />
+          <Key className="size-3.5" />
         </Button>
       </PopoverTrigger>
       <PopoverContent

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -58,14 +58,14 @@ export default function Editor() {
   }, []);
 
   return (
-    <div className="h-full p-4 pl-2">
+    <div className="h-full">
       <ToolbarPlugin />
       <RichTextPlugin
         ErrorBoundary={LexicalErrorBoundary}
         contentEditable={
-          <div className="border-border has-[:focus]:border-ring has-[:focus]:ring-ring/50 relative h-[calc(100%-52px)] overflow-y-auto rounded-b-lg border focus-visible:ring-[3px] has-[:focus]:ring-[3px]">
+          <div className="border-border relative h-[calc(100%-52px)] overflow-y-auto border-t p-0.5 pr-1">
             <ContentEditable
-              className="rounded-b-lg p-4 outline-none"
+              className="focus:outline-foreground h-full p-4 focus:outline-2"
               onFocus={() => {
                 setIsFocused(true);
               }}

--- a/src/components/editor/plugins/shortcuts-plugin.tsx
+++ b/src/components/editor/plugins/shortcuts-plugin.tsx
@@ -43,7 +43,6 @@ import {
   isClearFormatting,
   isFormatCheckList,
   isFormatParagraph,
-  isInsertCodeBlock,
   isDecreaseFontSize,
   isFormatBulletList,
   isIncreaseFontSize,
@@ -98,8 +97,6 @@ export default function ShortcutsPlugin(): null {
         editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'subscript');
       } else if (isSuperscript(event)) {
         editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'superscript');
-      } else if (isInsertCodeBlock(event)) {
-        editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
       } else if (isIncreaseFontSize(event)) {
         updateFontSize(
           editor,

--- a/src/components/editor/plugins/toolbar-plugin/toolbar-editor-plugin.tsx
+++ b/src/components/editor/plugins/toolbar-plugin/toolbar-editor-plugin.tsx
@@ -1,5 +1,4 @@
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
-import type { HeadingTagType } from '@lexical/rich-text';
 import { REDO_COMMAND, UNDO_COMMAND, FORMAT_TEXT_COMMAND } from 'lexical';
 import {
   BoldIcon,
@@ -8,12 +7,6 @@ import {
   RedoIcon,
   TypeIcon,
   ItalicIcon,
-  Heading1Icon,
-  Heading2Icon,
-  Heading3Icon,
-  Heading4Icon,
-  Heading5Icon,
-  Heading6Icon,
   UnderlineIcon,
   ChevronDownIcon,
   TextInitialIcon,
@@ -38,53 +31,10 @@ import {
   TooltipProvider,
 } from '@/components/ui/tooltip';
 import EDITOR_SHORTCUTS from '@/lib/constants/editor-shortcuts';
+import headings from '@/lib/constants/editor-toolbar-headings';
 import useEditorToolbarSync from '@/lib/hooks/use-editor-toolbar-sync';
 import useTooltipGroup from '@/lib/hooks/use-tooltip-group';
 import { formatHeading, formatParagraph } from '@/lib/utils/editor-formatters';
-
-const headingLevels: {
-  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
-  label: string;
-  shortcut: string;
-  value: HeadingTagType;
-}[] = [
-  {
-    icon: Heading1Icon,
-    label: 'Heading 1',
-    shortcut: EDITOR_SHORTCUTS.HEADING1,
-    value: 'h1',
-  },
-  {
-    icon: Heading2Icon,
-    label: 'Heading 2',
-    shortcut: EDITOR_SHORTCUTS.HEADING2,
-    value: 'h2',
-  },
-  {
-    icon: Heading3Icon,
-    label: 'Heading 3',
-    shortcut: EDITOR_SHORTCUTS.HEADING3,
-    value: 'h3',
-  },
-  {
-    icon: Heading4Icon,
-    label: 'Heading 4',
-    shortcut: EDITOR_SHORTCUTS.HEADING4,
-    value: 'h4',
-  },
-  {
-    icon: Heading5Icon,
-    label: 'Heading 5',
-    shortcut: EDITOR_SHORTCUTS.HEADING5,
-    value: 'h5',
-  },
-  {
-    icon: Heading6Icon,
-    label: 'Heading 6',
-    shortcut: EDITOR_SHORTCUTS.HEADING6,
-    value: 'h6',
-  },
-];
 
 export default function ToolbarEditorPlugin() {
   const [editor] = useLexicalComposerContext();
@@ -95,7 +45,7 @@ export default function ToolbarEditorPlugin() {
   return (
     <div
       onMouseLeave={tooltipGroup.onGroupMouseLeave}
-      className="border-border flex flex-wrap items-center gap-2 rounded-t-lg border border-b-0 p-2 md:flex-nowrap md:overflow-x-auto"
+      className="flex flex-wrap items-center gap-2 p-2 md:flex-nowrap md:overflow-x-auto"
     >
       <div className="[&>*]:rounded-none [&>*]:first:rounded-l-md [&>*]:last:rounded-r-md">
         <TooltipProvider>
@@ -272,14 +222,14 @@ export default function ToolbarEditorPlugin() {
         <DropdownMenuTrigger asChild className="w-40 justify-between">
           <Button size="sm" variant="outline">
             <TypeIcon className="mr-1 h-4 w-4" />
-            {headingLevels.find((h) => {
+            {headings.find((h) => {
               return h.value === toolbarState.blockType;
             })?.label || 'Normal text'}
             <ChevronDownIcon className="ml-1 h-3 w-3" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>
-          {headingLevels.map((heading) => {
+          {headings.map((heading) => {
             return (
               <DropdownMenuItem
                 key={heading.value}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import cn from '@/lib/utils/cn';
 
 const alertVariants = cva(
-  'relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
+  'relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 overflow-auto rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
   {
     defaultVariants: {
       variant: 'default',

--- a/src/lib/constants/editor-toolbar-headings.ts
+++ b/src/lib/constants/editor-toolbar-headings.ts
@@ -1,0 +1,58 @@
+import type { HeadingTagType } from '@lexical/rich-text';
+import {
+  Heading1Icon,
+  Heading2Icon,
+  Heading3Icon,
+  Heading4Icon,
+  Heading5Icon,
+  Heading6Icon,
+} from 'lucide-react';
+import type * as React from 'react';
+
+import EDITOR_SHORTCUTS from '@/lib/constants/editor-shortcuts';
+
+const headings: {
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  label: string;
+  shortcut: string;
+  value: HeadingTagType;
+}[] = [
+  {
+    icon: Heading1Icon,
+    label: 'Heading 1',
+    shortcut: EDITOR_SHORTCUTS.HEADING1,
+    value: 'h1',
+  },
+  {
+    icon: Heading2Icon,
+    label: 'Heading 2',
+    shortcut: EDITOR_SHORTCUTS.HEADING2,
+    value: 'h2',
+  },
+  {
+    icon: Heading3Icon,
+    label: 'Heading 3',
+    shortcut: EDITOR_SHORTCUTS.HEADING3,
+    value: 'h3',
+  },
+  {
+    icon: Heading4Icon,
+    label: 'Heading 4',
+    shortcut: EDITOR_SHORTCUTS.HEADING4,
+    value: 'h4',
+  },
+  {
+    icon: Heading5Icon,
+    label: 'Heading 5',
+    shortcut: EDITOR_SHORTCUTS.HEADING5,
+    value: 'h5',
+  },
+  {
+    icon: Heading6Icon,
+    label: 'Heading 6',
+    shortcut: EDITOR_SHORTCUTS.HEADING6,
+    value: 'h6',
+  },
+];
+
+export default headings;


### PR DESCRIPTION
Add persistent chat header containing theme selector and API key manager. The header maintains consistent height with the editor toolbar and is always visible regardless of API key status.

- Add ChatHeader component with theme toggle (light/dark/system)
- Integrate next-themes with ToggleGroup for theme switching
- Move API key manager button from floating position to header
- Refactor chat layout structure for header integration
- Update editor and chat styling for visual consistency
- Extract heading definitions to constants file
- Remove code block shortcut (Cmd+E) to prevent conflicts
- Adjust ResizableHandle styling and alert overflow handling

Theme preference defaults to system and persists in localStorage.